### PR TITLE
enable model class overload via DI

### DIFF
--- a/src/models/crud/ActiveRecord.php
+++ b/src/models/crud/ActiveRecord.php
@@ -17,5 +17,20 @@ namespace dmstr\modules\publication\models\crud;
  */
 class ActiveRecord extends \yii\db\ActiveRecord
 {
+    /**
+     * overwrite \yii\db\BaseActiveRecord::instantiate() to be able to overload model classes returned by ActiveQuery
+     *
+     * The default implementation return new static() models, but Yii::createObject()
+     * must be used to be able to overload model classes via DI
+     *
+     * @param array $row
+     *
+     * @return ActiveRecord|object
+     * @throws \yii\base\InvalidConfigException
+     */
+    public static function instantiate($row)
+    {
+        return \Yii::createObject(static::class);
+    }
 
 }


### PR DESCRIPTION
This PR overwrite \yii\db\BaseActiveRecord::instantiate()

The BaseActiveRecord::instantiate() implementation return new static() models, but Yii::createObject() must be used to be able to overload model classes returned by ActiveQuery via DI