### PR TITLE
fixed publicationTag relations

### DIFF
--- a/src/controllers/crud/PublicationItemController.php
+++ b/src/controllers/crud/PublicationItemController.php
@@ -135,7 +135,14 @@ class PublicationItemController extends BaseController
 
         $attachedTags = $model->tags;
 
-        $otherTags = PublicationTag::find()->where(['NOT IN', 'id', ArrayHelper::map($attachedTags, 'id', 'id')])->all();
+        $otherTagsQuery = PublicationTag::find()->where(['NOT IN', 'id', ArrayHelper::map($attachedTags, 'id', 'id')]);
+        $qLangs = [Yii::$app->language];
+        if (!empty(\Yii::$app->params['fallbackLanguages'][\Yii::$app->language])) {
+            $qLangs[] = \Yii::$app->params['fallbackLanguages'][\Yii::$app->language];
+        }
+        $otherTagsQuery->andWhere(['ref_lang' => $qLangs]);
+
+        $otherTags = $otherTagsQuery->all();
 
         PublicationAttachAssetBundle::register($this->view);
 

--- a/src/views/crud/publication-item/index.php
+++ b/src/views/crud/publication-item/index.php
@@ -140,7 +140,11 @@ $this->registerJs('$(function () {$(\'[data-toggle="tooltip"]\').tooltip()})');
                                     $tags[] =  Html::a(Html::encode($label),['/publication/crud/publication-tag/view','id' => $id],['class' => 'label label-default']);
                                 }
 
-                                $tags[] =  Html::a(FA::icon(FA::_PLUS),['/publication/crud/publication-item/attach','id' => $model->id],['class' => 'label label-success']);
+                                // attach tags is only allowed for "own" items
+                                // see: \dmstr\modules\publication\controllers\crud\PublicationItemController::actionAttach()
+                                if ($model->ref_lang === Yii::$app->language) {
+                                    $tags[] =  Html::a(FA::icon(FA::_PLUS),['/publication/crud/publication-item/attach','id' => $model->id],['class' => 'label label-success']);
+                                }
 
                                 return implode(' ', $tags);
 


### PR DESCRIPTION
This PR fixes publicationTag relations in multi-lang apps:

- changed PublicationTag search model query: get only those tags with allowed ref_lang
- changed PublicationTag::find() conditions in PublicationItem::attach() action: get only those tags with allowed ref_lang
- changed publication-item/view: show attach-tag link only if allowed in current app->lang

