### PR TITLE
set page title from item::title in detail view

### DIFF
--- a/src/views/default/detail.php
+++ b/src/views/default/detail.php
@@ -8,7 +8,12 @@
 use dmstr\modules\publication\widgets\Publication;
 use hrzg\widget\widgets\Cell;
 
-$this->title = Yii::$app->settings->get('site', 'publication.default-detail') ?: Yii::t('publication', 'Detail');
+if (!empty($item->title)) {
+    $title  = $item->title;
+} else {
+    $title = Yii::$app->settings->get('site', 'publication.default-detail') ?: Yii::t('publication', 'Detail');
+}
+$this->title = htmlspecialchars($title, ENT_NOQUOTES, Yii::$app ? Yii::$app->charset : 'UTF-8', false);
 ?>
 <div class="publication-default-detail">
     <?= Cell::widget(['id' => 'publication_detail_top', 'requestParam' => 'publication_detail_top']) ?>


### PR DESCRIPTION
This PR sets the page title in detail view from item::title attribute, fallback to the value from settings as before.

htmlspecialchars() instead of yii Html::encode is used here, as encoded quotes in title tag would be displayed "as is".